### PR TITLE
Add possibility to configure multiple GenericRepositories

### DIFF
--- a/src/Vivarni.DDD.Infrastructure/ServiceCollectionExtension.cs
+++ b/src/Vivarni.DDD.Infrastructure/ServiceCollectionExtension.cs
@@ -14,14 +14,20 @@ namespace Vivarni.DDD.Infrastructure
         /// <summary>
         /// Adds scoped services for <see cref="IGenericRepository{T}"/> and <see cref="IDomainEventBrokerService"/>.
         /// </summary>
-        public static IServiceCollection AddVivarniInfrastructure(this IServiceCollection @this, Action<VivarniInfrastructureOptionsBuilder> optionsBuilder)
+        public static IServiceCollection AddVivarniInfrastructure(this IServiceCollection @this, Action<VivarniInfrastructureOptionsBuilder> optionsBuilder = null)
         {
-            @this.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
             @this.AddScoped(typeof(IDomainEventBrokerService), typeof(DomainEventBrokerService));
 
             var options = new VivarniInfrastructureOptionsBuilder();
-            optionsBuilder.Invoke(options);
+            if (optionsBuilder != null)
+                optionsBuilder.Invoke(options);
             @this.Add(new ServiceDescriptor(typeof(ICachingProvider), options.CachingProviderType, options.CachingProviderServiceLifetime));
+
+            options.GenericRepositories.TryAdd(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+            foreach (var genericRepository in options.GenericRepositories)
+            {
+                @this.AddScoped(genericRepository.Key, genericRepository.Value);
+            }
 
             return @this;
         }

--- a/src/Vivarni.DDD.Infrastructure/VivarniInfrastructureOptionsBuilder.cs
+++ b/src/Vivarni.DDD.Infrastructure/VivarniInfrastructureOptionsBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
+using Vivarni.DDD.Core.Repositories;
 using Vivarni.DDD.Infrastructure.Caching;
 
 namespace Vivarni.DDD.Infrastructure
@@ -12,7 +14,7 @@ namespace Vivarni.DDD.Infrastructure
         /// <summary>
         /// The <see cref="ICachingProvider"/> type used by <see cref="GenericRepository{T}"/>.
         /// </summary>
-        public Type CachingProviderType { internal get; set; } = typeof(CachingProviderStub);
+        internal Type CachingProviderType { get; set; } = typeof(CachingProviderStub);
 
         /// <summary>
         /// Service lifetime for the <see cref="ICachingProvider"/> used by <see cref="GenericRepository{T}"/>.
@@ -20,13 +22,32 @@ namespace Vivarni.DDD.Infrastructure
         internal ServiceLifetime CachingProviderServiceLifetime { get; set; }
 
         /// <summary>
+        /// Additional <see cref="IGenericRepository{T}"/> registrations
+        /// </summary>
+        internal Dictionary<Type, Type> GenericRepositories { get; set; } = new Dictionary<Type, Type>();
+
+        /// <summary>
         /// Configures the <see cref="ICachingProvider"/> type to be used by <see cref="GenericRepository{T}"/> with the provided service <paramref name="lifeTime"/>.
         /// </summary>
-        public void WithCachingProvider<T>(ServiceLifetime lifeTime = ServiceLifetime.Scoped)
+        public VivarniInfrastructureOptionsBuilder WithCachingProvider<T>(ServiceLifetime lifeTime = ServiceLifetime.Scoped)
             where T : ICachingProvider
         {
             CachingProviderType = typeof(T);
             CachingProviderServiceLifetime = lifeTime;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configures your own implementation and interface for <see cref="IGenericRepository{T}"/>
+        /// 
+        /// This method may be used to register additional (multiple) sub interfaces of <see cref="IGenericRepository{T}"/>
+        /// </summary>
+        public VivarniInfrastructureOptionsBuilder WithGenericRepository(Type genericRepositoryInterface, Type genericRepositoryImplementation)
+        {
+            GenericRepositories.TryAdd(genericRepositoryInterface, genericRepositoryImplementation);
+
+            return this;
         }
     }
 }


### PR DESCRIPTION
In order to support deviations of GenericRepository (additional methods, ,multiple DbContexts) we should have extension methods that allows us to configure it