### PR TITLE
Extra bulk methods for GenericRepository

### DIFF
--- a/src/Vivarni.DDD.Core/Repositories/IGenericRepository.cs
+++ b/src/Vivarni.DDD.Core/Repositories/IGenericRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ardalis.Specification;
@@ -130,12 +131,27 @@ namespace Vivarni.DDD.Core.Repositories
         Task<T> AddAsync(T entity, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Asynchronously adds the provided <paramref name="entities"/> to the database.
+        /// </summary>
+        /// <param name="entities">The entities to add.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the added entity.</returns>
+        Task<IEnumerable<T>> AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Asynchronously updates the provided <paramref name="entity"/> in the database.
         /// </summary>
         /// <param name="entity">The entity to update.</param>
         /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         Task UpdateAsync(T entity, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously updates the provided <paramref name="entities"/> in the database.
+        /// </summary>
+        /// <param name="entities">The entities to update.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task UpdateRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously removes the provided <paramref name="entity"/> from the database.
@@ -144,5 +160,12 @@ namespace Vivarni.DDD.Core.Repositories
         /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         Task DeleteAsync(T entity, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously removes the provided <paramref name="entities"/> from the database.
+        /// </summary>
+        /// <param name="entities">The entity to delete.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task DeleteRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Vivarni.DDD.Infrastructure/Repositories/GenericRepository.cs
+++ b/src/Vivarni.DDD.Infrastructure/Repositories/GenericRepository.cs
@@ -272,5 +272,27 @@ namespace Vivarni.DDD.Infrastructure
             var evaluator = SpecificationEvaluator.Default;
             return evaluator.GetQuery(_ctx.Set<T>().AsQueryable(), spec);
         }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<T>> AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        {
+            await _ctx.Set<T>().AddRangeAsync(entities, cancellationToken);
+            await _ctx.SaveChangesAsync(cancellationToken);
+
+            return entities;
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        {
+            await _ctx.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task DeleteRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        {
+            _ctx.Set<T>().RemoveRange(entities);
+            await _ctx.SaveChangesAsync(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
At the moment to keep bulk operations safe we always have to explicitly wrap it inside a transaction.
These bulk methods would take care of that with the power of EF.

Good idea?