### PR TITLE
Update NuGet Packages + Limit support to NET8 and NET9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Test
         run: dotnet test --no-build --verbosity normal
 
-      - name: Debug
-        run: echo ${{github.event_name}}
-
       # publish Core on version change
       - name: publish Core on version change
         id: publish_core

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,10 +29,13 @@ jobs:
       - name: Test
         run: dotnet test --no-build --verbosity normal
 
+      - name: Debug
+        run: echo ${{github.event_name}}
+
       # publish Core on version change
       - name: publish Core on version change
         id: publish_core
-        if: success()
+        if: github.event_name == 'push' && success()
         uses: Clivar/publish-nuget@master
         with:
           # Filepath of the project to be packaged, relative to root of repository
@@ -65,7 +68,7 @@ jobs:
       # publish Infrastructure on version change
       - name: publish Infrastructure on version change
         id: publish_infrastructure
-        if: success()
+        if: github.event_name == 'push' && success()
         uses: Clivar/publish-nuget@master
         with:
           # Filepath of the project to be packaged, relative to root of repository

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 9.0.x
 
       # dotnet restore
       - name: Restore dependencies

--- a/sample/Vivarni.Example.API/Vivarni.Example.API.csproj
+++ b/sample/Vivarni.Example.API/Vivarni.Example.API.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.13">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/Vivarni.Example.Domain/Vivarni.Example.Domain.csproj
+++ b/sample/Vivarni.Example.Domain/Vivarni.Example.Domain.csproj
@@ -1,8 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -11,8 +10,8 @@
     <ProjectReference Include="..\..\src\Vivarni.DDD.Core\Vivarni.DDD.Core.csproj" />    
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Scrutor" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/sample/Vivarni.Example.Infrastructure/Vivarni.Example.Infrastructure.SQLite.csproj
+++ b/sample/Vivarni.Example.Infrastructure/Vivarni.Example.Infrastructure.SQLite.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.13" />
-    <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
+    <PackageReference Include="Scrutor" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vivarni.DDD.Core/IEntityWithDomainEvents.cs
+++ b/src/Vivarni.DDD.Core/IEntityWithDomainEvents.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Ardalis.Specification;
 
 namespace Vivarni.DDD.Core
 {
@@ -9,7 +8,6 @@ namespace Vivarni.DDD.Core
     public interface IEntityWithDomainEvents
     {
         /// <summary>
-        /// List of events carried by this <see cref="IEntity{TId}"/>.
         /// This property should be ignored by Entity Framework.
         /// </summary>
         public List<IDomainEvent> Events { get; }
@@ -22,5 +20,5 @@ namespace Vivarni.DDD.Core
     /// database. Such a mechanism is provided in <c>Vivarni.Domain.Infrastructure</c>.
     /// </summary>
     /// <seealso href="https://github.com/vivarni/vivarni.domain"/>
-    public interface IEntityWithDomainEvents<TId> : IEntity<TId>, IEntityWithDomainEvents { }
+    public interface IEntityWithDomainEvents<TId> : IEntityWithDomainEvents { }
 }

--- a/src/Vivarni.DDD.Core/IEntityWithDomainEvents.cs
+++ b/src/Vivarni.DDD.Core/IEntityWithDomainEvents.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Vivarni.DDD.Core
 {
@@ -21,5 +22,6 @@ namespace Vivarni.DDD.Core
     /// database. Such a mechanism is provided in <c>Vivarni.Domain.Infrastructure</c>.
     /// </summary>
     /// <seealso href="https://github.com/vivarni/vivarni.domain"/>
+    [Obsolete("Replace the usage of this generic interface with the non-generic variant. Will be removed in future releases.")]
     public interface IEntityWithDomainEvents<TId> : IEntityWithDomainEvents { }
 }

--- a/src/Vivarni.DDD.Core/IEntityWithDomainEvents.cs
+++ b/src/Vivarni.DDD.Core/IEntityWithDomainEvents.cs
@@ -8,6 +8,7 @@ namespace Vivarni.DDD.Core
     public interface IEntityWithDomainEvents
     {
         /// <summary>
+        /// List of events carried by this entity.
         /// This property should be ignored by Entity Framework.
         /// </summary>
         public List<IDomainEvent> Events { get; }

--- a/src/Vivarni.DDD.Core/Repositories/IGenericRepository.cs
+++ b/src/Vivarni.DDD.Core/Repositories/IGenericRepository.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ardalis.Specification;

--- a/src/Vivarni.DDD.Core/Vivarni.DDD.Core.csproj
+++ b/src/Vivarni.DDD.Core/Vivarni.DDD.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <Version>2.0.4</Version>
+    <Version>2.1.0</Version>
     <Authors>Michaël Vittorelli; Anthony Van Dooren</Authors>
     <RepositoryUrl>https://github.com/vivarni/vivarni.domain</RepositoryUrl>
     <PackageProjectUrl>https://github.com/vivarni/vivarni.domain</PackageProjectUrl>

--- a/src/Vivarni.DDD.Core/Vivarni.DDD.Core.csproj
+++ b/src/Vivarni.DDD.Core/Vivarni.DDD.Core.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.Specification" Version="7.0.0" />
+    <PackageReference Include="Ardalis.Specification" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vivarni.DDD.Infrastructure/Vivarni.DDD.Infrastructure.csproj
+++ b/src/Vivarni.DDD.Infrastructure/Vivarni.DDD.Infrastructure.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <Version>2.0.4</Version>
+    <Version>2.1.0</Version>
     <Authors>Michaël Vittorelli; Anthony Van Dooren</Authors>
     <RepositoryUrl>https://github.com/vivarni/vivarni.domain</RepositoryUrl>
     <PackageProjectUrl>https://github.com/vivarni/vivarni.domain</PackageProjectUrl>

--- a/src/Vivarni.DDD.Infrastructure/Vivarni.DDD.Infrastructure.csproj
+++ b/src/Vivarni.DDD.Infrastructure/Vivarni.DDD.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Version>2.0.4</Version>
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
### Supported Frameworks
Support for NET6 and NET7 has been replaced by NET8 and NET9, seeing the [Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy) from Microsoft.


Version | Original release date | Latest patch version | Patch release date | Release type | Support phase | End of support
-- | -- | -- | -- | -- | -- | --
.NET 9 | November 12, 2024 | 9.0.4 | April 8, 2025 | STS | Active | May 12, 2026
.NET 8 | November 14, 2023 | 8.0.15 | April 8, 2025 | LTS | Active | November 10, 2026

### Removal of IEntity<TId>

Also, `IEntity<TId>` has been removed by the Ardalis package. It is therefore also removed from our `IEntityWithDomainEvents` interface. The generic interface has been marked obsolete and should be removed in future releases.

### Question: Future version number

~~What version number should be bump our packages to?~~ @ingkor suggested 2.1.0